### PR TITLE
BLD: pyqt build restrictions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,10 +27,6 @@ install:
   - conda config --append channels conda-forge
   # Useful for debugging any issues with conda
   - conda info -a
-  # Take from docs.travis-ci.com/user/gui-and-headless-browsers
-  - "export DISPLAY=:99.0"
-  - "sh -e /etc/init.d/xvfb start"
-  - sleep 3 # give xvfb some time to start
 
 script:
   # We're actually *only* testing the conda build here.

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,15 @@
 language: python
 sudo: false
 
+services:
+    - xvfb
+
+addons:
+    apt:
+      packages:
+        - herbstluftwm
+        - libxkbcommon-x11-0
+
 env:
   global:
     - OFFICIAL_REPO="pcdshub/pmgr"
@@ -27,6 +36,11 @@ install:
   - conda config --append channels conda-forge
   # Useful for debugging any issues with conda
   - conda info -a
+
+before_script:
+  # Run windows manager
+  - "herbstluftwm &"
+  - sleep 1
 
 script:
   # We're actually *only* testing the conda build here.

--- a/README.md
+++ b/README.md
@@ -2,4 +2,4 @@
 
 Package used in LCLS to manage motor parameters. Currently in use to manage configurations for IMS motors in the LCLS1 hard x-ray hutches.
 
-The conda build does not support the GUI, which requires a specific build of pyqt that adds some types that can be emitted that are cruicial for the table to work.
+The conda build does not support the GUI, which requires a specific build of pyqt that adds some types that can be emitted that are crucial for the table to work.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,5 @@
+## Parameter Manager
+
+Package used in LCLS to manage motor parameters. Currently in use to manage configurations for IMS motors in the LCLS1 hard x-ray hutches.
+
+The conda build does not support the GUI, which requires a specific build of pyqt that adds some types that can be emitted that are cruicial for the table to work.

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -19,7 +19,7 @@ requirements:
 
   run:
     - python {{PY_VER}}*,>=3.6
-    - pyqt =5.6
+    - pyqt >=5
     - pyca >=3
     - pykerberos >=1.1.14
     - mysqlclient =1.3.12


### PR DESCRIPTION
Resolve dependency conflict between lucid and pmgr for hutch python conda.

We avoid the runtime issue with pyqt by not running the gui