### PR TITLE
BLD: pin conda recipe pyca/epicscorelibs to a working combination

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -21,7 +21,8 @@ requirements:
   run:
     - python >=3.6
     - pyqt >=5
-    - pyca >=3
+    - pyca =3.1.1
+    - epicscorelibs =7.0.3.99.4.0
     - pykerberos >=1.1.14
     - mysqlclient =1.3.12|>=2.0.3
     - docopt


### PR DESCRIPTION
Currently the `pyca` `conda-forge` recipe allows itself to be run with any version of `epicscorelibs`, even though it only works with the one it was compiled against. Rather than figure out how to fix that recipe today, just opt to pin to a working combination for the recipe build.

These are the versions we've been using in pcds-envs for a while now.