### PR TITLE
Switch to Production Database

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
 ## Parameter Manager
 
 Package used in LCLS to manage motor parameters. Currently in use to manage configurations for IMS motors in the LCLS1 hard x-ray hutches.
-
-The conda build does not support the GUI, which requires a specific build of pyqt that adds some types that can be emitted that are crucial for the table to work.

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -22,7 +22,7 @@ requirements:
     - python >=3.6
     - pyqt >=5
     - pyca =3.1.1
-    - epicscorelibs =7.0.3.99.4.0
+    - epicscorelibs =7.0.4.99.1.2
     - pykerberos >=1.1.14
     - mysqlclient =1.3.12|>=2.0.3
     - docopt

--- a/do_release
+++ b/do_release
@@ -13,13 +13,14 @@ conda activate "${VER}"
 mkdir --parents $1/lib/python3.8/site-packages/
 export PYTHONPATH=$1/lib/python3.8/site-packages/
 python setup.py install --prefix=$1
+EGG=`ls $1/lib/python3.8/site-packages/pmgr*egg`
 cat >$1/pmgr <<END
 #!/bin/bash
 unset PYTHONPATH
 unset LD_LIBRARY_PATH
 source /reg/g/pcds/pyps/conda/py36/etc/profile.d/conda.sh
 conda activate "${VER}"
-export PYTHONPATH=$1/lib/python3.8/site-packages/
+export PYTHONPATH=${EGG}
 $1/bin/pmgrLauncher.sh \$*
 END
 chmod guo+x $1/pmgr

--- a/pmgr/db.py
+++ b/pmgr/db.py
@@ -1,5 +1,6 @@
 import threading
 import time
+import sys
 
 from PyQt5 import QtCore
 
@@ -41,7 +42,9 @@ class db(QtCore.QObject):
         super(db, self).__init__()
         self.nameedits = {}
         self.errordialog = dialogs.errordialog()
-        param.params.pobj = pmgrobj(param.params.table, param.params.hutch, param.params.debug)
+        param.params.pobj = pmgrobj(param.params.table, param.params.hutch, 
+                                    debug=param.params.debug, 
+                                    prod=param.params.prod)
         self.poll = None
         self.readTables()
         self.readsig.connect(self.readTables)

--- a/pmgr/migrate/README
+++ b/pmgr/migrate/README
@@ -1,8 +1,9 @@
 TL;DR - To convert the first version of the parameter manager database to the
-current version, run the following from the top directory:
+current version, run the following commands from the top directory:
+
     cat pmgr/migrate/sql.script |\
         mysql --host=psdb --user=pscontrols --password=pcds --database=pscontrols'
-    python pmgr/migrate/fixup.py
+    python pmgr/migrate/fixup.py --prod
     cat pmgr/migrate/sql.script2 |\
         mysql --host=psdb --user=pscontrols --password=pcds --database=pscontrols'
 

--- a/pmgr/migrate/fixup.py
+++ b/pmgr/migrate/fixup.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 import pmgrobj
+import sys
+import ..options
 
 #from pmgrobj import pmgrobj
 
@@ -30,6 +32,7 @@ def assign_mutex(p, cfg, m, full, cm):
     return f
 
 def main():
+    sys.exit(0)
     p = pmgrobj.pmgrobj('ims_motor', None)
     # Fixup the mutex field in configurations, and build out the configuration with
     # no inheritance.

--- a/pmgr/migrate/fixup.py
+++ b/pmgr/migrate/fixup.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 import pmgrobj
 import sys
-import ..options
 
 #from pmgrobj import pmgrobj
 
@@ -32,8 +31,16 @@ def assign_mutex(p, cfg, m, full, cm):
     return f
 
 def main():
-    sys.exit(0)
-    p = pmgrobj.pmgrobj('ims_motor', None)
+    prod = None
+    for a in sys.argv:
+        if a == '--prod':
+            prod = True
+        elif a == '--dev':
+            prod = False
+    if prod is None:
+        print("Usage: fixup [--prod | --dev]")
+        sys.exit(0)
+    p = pmgrobj.pmgrobj('ims_motor', None, prod=prod)
     # Fixup the mutex field in configurations, and build out the configuration with
     # no inheritance.
     for i in p.cfgs.keys():

--- a/pmgr/migrate/pmgrobj.py
+++ b/pmgr/migrate/pmgrobj.py
@@ -206,7 +206,7 @@ class pmgrobj(object):
     unwanted = ['seq', 'owner', 'id', 'category', 'dt_created',
                 'date', 'dt_updated', 'name', 'action', 'rec_base', 'comment']
 
-    def __init__(self, table, hutch, debug=False):
+    def __init__(self, table, hutch, debug=False, prod=True):
         self.table = table
         self.hutch = hutch
         self.debug = debug
@@ -217,7 +217,7 @@ class pmgrobj(object):
         self.errorlist = []
         self.autoconfig = None
         self.in_trans = False
-        if False:
+        if prod:
             print("Using production server.")
             self.con = mdb.connect('psdb', 'pscontrols', 'pcds', 'pscontrols')
         else:

--- a/pmgr/pmgr.py
+++ b/pmgr/pmgr.py
@@ -202,8 +202,8 @@ def main():
 
     param.params.setHutch(options.hutch.lower())
     param.params.setTable(options.type)
-    param.params.debug = False if options.debug == None else True
-    param.params.applyOK = False if options.applyenable == None else True
+    param.params.debug = False if options.debug is None else True
+    param.params.applyOK = False if options.applyenable is None else True
     param.params.prod = True if options.dev is None else False
     gui = GraphicUserInterface()
     param.params.setTable(options.type)  # Sigh, do this again to fix dropdown.

--- a/pmgr/pmgr.py
+++ b/pmgr/pmgr.py
@@ -189,10 +189,14 @@ def main():
     app = QtWidgets.QApplication([''])
   
     # Options( [mandatory list, optional list, switches list] )
-    options = Options(['hutch', 'type'], [], ['debug', 'applyenable'])
+    options = Options(['hutch', 'type'], [], ['debug', 'applyenable', 'dev', 'help'])
     try:
         options.parse()
     except Exception as msg:
+        options.usage(str(msg))
+        sys.exit()
+
+    if options.help is not None:
         options.usage(str(msg))
         sys.exit()
 
@@ -200,6 +204,7 @@ def main():
     param.params.setTable(options.type)
     param.params.debug = False if options.debug == None else True
     param.params.applyOK = False if options.applyenable == None else True
+    param.params.prod = True if options.dev is None else False
     gui = GraphicUserInterface()
     param.params.setTable(options.type)  # Sigh, do this again to fix dropdown.
     # MCB - We need a better way of doing this.

--- a/pmgr/pmgrobj.py
+++ b/pmgr/pmgrobj.py
@@ -187,7 +187,7 @@ class pmgrobj(object):
     unwanted = ['seq', 'owner', 'id', 'category', 'dt_created',
                 'date', 'dt_updated', 'name', 'action', 'rec_base', 'comment']
 
-    def __init__(self, table, hutch, debug=False):
+    def __init__(self, table, hutch, debug=False, prod=True):
         self.table = table
         self.hutch = hutch
         self.debug = debug
@@ -196,7 +196,7 @@ class pmgrobj(object):
         self.errorlist = []
         self.autoconfig = None
         self.in_trans = False
-        if False:
+        if prod:
             print("Using production server.")
             self.con = mdb.connect('psdb', 'pscontrols', 'pcds', 'pscontrols')
         else:


### PR DESCRIPTION
The Brave New World used the development database.  Change pmgr.py to default to production, but accept a --dev flag, and change the migration fixup.py to take --dev or --prod switches.
