### PR TITLE
Fix Sorting on Object Owner Column

### DIFF
--- a/pmgr/ObjModel.py
+++ b/pmgr/ObjModel.py
@@ -435,7 +435,11 @@ class ObjModel(QtGui.QStandardItemModel):
             return self.edits[idx][f]
         except:
             try:
-                return self.getObj(idx)[f]
+                x = self.getObj(idx)[f]
+                if x is None:
+                    return ""
+                else:
+                    return x
             except:
                 return ""
 


### PR DESCRIPTION
The "default" motor doesn't have an owner (the db entry is NULL).  This produces problems when you try to sort on the owner column.  Like segmentation fault problems.

