### PR TITLE
Merge Mike's update for R2.0.3

### DIFF
--- a/pmgr/DB/ims_motor_cfg.sql
+++ b/pmgr/DB/ims_motor_cfg.sql
@@ -5,7 +5,7 @@
 DROP TABLE IF EXISTS `ims_motor_cfg`;
 CREATE TABLE `ims_motor_cfg` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
-  `name` varchar(15) NOT NULL UNIQUE,
+  `name` varchar(45) NOT NULL UNIQUE,
   `config` int(11),
   `dt_updated` datetime NOT NULL,
   `mutex` varchar(16),

--- a/pmgr/DB/ims_motor_cfg_log.sql
+++ b/pmgr/DB/ims_motor_cfg_log.sql
@@ -10,7 +10,7 @@ CREATE TABLE `ims_motor_cfg_log` (
   `seq` int(31) NOT NULL AUTO_INCREMENT,
   `action` varchar(10) NOT NULL,
   `id` int(11) NOT NULL,
-  `name` varchar(15),
+  `name` varchar(45),
   `config` int(11),
   `dt_updated` datetime,
   `mutex` varchar(16),

--- a/pmgr/pmgrAPI.py
+++ b/pmgr/pmgrAPI.py
@@ -273,7 +273,7 @@ class pmgrAPI(object):
                 raise Exception("DB Errors", el)
             self.set_config(pv, cfgname)
 
-    def match_config(self, pattern, substr=True, ci=True):
+    def match_config(self, pattern, substr=True, ci=True, parent=None):
         """
         Find configurations that match a given pattern.
 
@@ -291,6 +291,10 @@ class pmgrAPI(object):
             If True, do a case insensitive match, otherwise be case
             sensitive.  (Default to True.)
 
+        parent : str
+            The name of a parent configuration.  Only match children of
+            this configuration.
+
         Returns
         -------
         clist : list
@@ -299,5 +303,5 @@ class pmgrAPI(object):
         Throws an exception if there is a database problem.
         """
         self.update_db()
-        return self.pm.matchConfigs(pattern, substr, ci)
+        return self.pm.matchConfigs(pattern, substr, ci, parent)
 


### PR DESCRIPTION
Here are @mcb64 's changes for allowing us to search for configurations from a specific parent. This was tagged at R2.0.3 in his github and deployed as such for the pmgr gui application.

I'm pulling this in now because I'm updating our conda env for use in the `hutch-python` sessions that want this feature.

After merging and doing a follow-up to fix some other packaging things, I will tag as R2.1.0 to avoid clobbering the existing R2.0.3 tag which doesn't have some of the miscellaneous packaging updates.