### PR TITLE
BLD/CI: update to the next pyca update

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -20,7 +20,7 @@ requirements:
 
   run:
     - python >=3.6
-    - pyqt >=5
+    - pyqt >=5,<5.15
     - pyca =3.2.0
     - epicscorelibs =7.0.6.99.2.0
     - pykerberos >=1.1.14

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -8,7 +8,7 @@ source:
   path: ..
 
 build:
-  number: 1
+  number: 0
   noarch: python
   script:
     python setup.py install --single-version-externally-managed --record=record.txt
@@ -21,8 +21,8 @@ requirements:
   run:
     - python >=3.6
     - pyqt >=5
-    - pyca =3.1.1
-    - epicscorelibs =7.0.4.99.1.2
+    - pyca =3.2.0
+    - epicscorelibs =7.0.6.99.2.0
     - pykerberos >=1.1.14
     - mysqlclient =1.3.12|>=2.0.3
     - docopt


### PR DESCRIPTION
The conda build here is still a bit unstable due to deficiencies in the pyca recipe which we'll take care of later. Once that is taken care of, these two dependencies can be completely unpinned.

For now, update both pins in lockstep

We want to use the newer pyca in the conda envs because it has bugfixes