### PR TITLE
Add configuration history routines.

### DIFF
--- a/pmgr/pmgrAPI.py
+++ b/pmgr/pmgrAPI.py
@@ -352,16 +352,17 @@ class pmgrAPI:
         """
         try:
             return datetime.fromisoformat(s)
-        except:
+        except ValueError:
             pass
         try:
             return datetime.strptime(s, "%m/%d/%Y %H:%M")
-        except:
+        except ValueError:
             pass
         try:
             return datetime.strptime(s, "%m/%d/%Y")
-        except:
+        except ValueError:
             pass
+        raise ValueError("Not a valid date: %s" % s)
 
     def config_history(self, cfgname, start=None, finish=None, diff=False):
         """

--- a/pmgr/pmgrAPI.py
+++ b/pmgr/pmgrAPI.py
@@ -1,5 +1,5 @@
 from .pmgrobj import pmgrobj
-
+from datetime import datetime
 
 class pmgrAPI:
     """
@@ -339,3 +339,56 @@ class pmgrAPI:
         el = self.pm.end_transaction()
         if el != []:
             raise Exception("DB Errors", el)
+
+    @staticmethod
+    def _get_datetime(s):
+        """
+        Try to convert a string into a datetime object.  The following
+        conversions are attempted:
+             ISO format
+             mm/dd/yyyy
+             mm/dd/yyyy hh:mm
+        If all three fail, a ValueError exception is raised.
+        """
+        try:
+            return datetime.fromisoformat(s)
+        except:
+            pass
+        try:
+            return datetime.strptime(s, "%m/%d/%Y %H:%M")
+        except:
+            pass
+        try:
+            return datetime.strptime(s, "%m/%d/%Y")
+        except:
+            pass
+
+    def config_history(self, cfgname, start=None, finish=None, diff=False):
+        """
+        Return the history of a configuration.
+
+        Parameters
+        ----------
+        config : str
+            The name of the configuration.
+
+        start, finish: date
+            The date range of interest (None == no limit).  These can be datetime
+            objects, or strings that are interpreted as either isoformat dates,
+            "mm/dd/yyyy" dates, or "mm/dd/yyyy hh:mm".  Formatting is rather
+            strict.
+
+        diff: boolean
+            Should updates be listed in full, or as a difference from the previous?
+
+        Returns
+        -------
+        A list of dictionaries mapping field names to configured values.  The "action"
+        keyword indicates what has been done here: "insert", "update" or "delete"
+        """
+        if type(start) == str:
+            start = self._get_datetime(start)
+        if type(finish) == str:
+            finish = self._get_datetime(start)
+        d = self._search(self.pm.cfgs, 'name', cfgname)
+        return self.pm.configHistory(d['id'], start, finish, diff)

--- a/pmgr/pmgrUtils.py
+++ b/pmgr/pmgrUtils.py
@@ -32,8 +32,10 @@ Commands:
     diff           Prints differences between pmgr and live values
     find           Find the configurations matching the given pattern
     history        Give the history of the configuration between the start
-                   and end dates.  Save a full listing as a CSV file,
-                   or get a difference between successive changes.
+                   and end dates.  Dates can be one of three formats:
+                   "2024-04-15 13:15", "3/24/2023", or "7/15/2022 15:27".
+                   Save a full listing as a CSV file, or get a difference 
+                   between successive changes.
 
 Options:
     -v|--verbose   Print more info on active process

--- a/pmgr/pmgrobj.py
+++ b/pmgr/pmgrobj.py
@@ -828,7 +828,7 @@ class pmgrobj:
                 l.append(self._cleanHistory(r, p, diff))
                 p = r
             return l
-        except:
+        except Exception:
             return []
 
     def objectDelete(self, idx):

--- a/pmgr/pmgrobj.py
+++ b/pmgr/pmgrobj.py
@@ -778,6 +778,59 @@ class pmgrobj:
         except _mysql_exceptions.Error as err:
             self.errorlist.append(err)
 
+    def _cleanHistory(self, cur, prev, diff):
+        """
+        Clean up the history a little for user display.
+
+        Get rid of internal fields, and generate a diff if
+        requested.
+        """
+        d = {'action': cur['action'], 'date': cur['dt_updated'], 'name': cur['name']}
+        if cur['action'] == 'delete':
+            return d
+        if cur['action'] == 'insert' or prev is None or not diff:
+            for fi in self.cfgflds:
+                f = fi['fld']
+                d[f] = cur[f]
+            return d
+        else:
+            # Generate a diff!
+            for fi in self.cfgflds:
+                f = fi['fld']
+                if prev[f] != cur[f]:
+                    d[f] = cur[f]
+            return d
+
+    def configHistory(self, idx, start=None, finish=None, diff=True):
+        """
+        Retrieve the history of the specified configuration between 
+        the specified dates.
+
+        start and finish are assumed to be datetime objects.  If
+        either or both is None, there is no time limit on that end.
+
+        If diff is true, only list how values have changed between
+        successive entries, otherwise give all field values.
+        """
+        try:
+            cmd = "select * from %s_cfg_log where id = %d" % (self.table, idx)
+            if start is not None:
+                if finish is not None:
+                    cmd = cmd + " and dt_updated between '%s' and '%s'" % (start, finish)
+                else:
+                    cmd = cmd + " and dt_updated >= '%s'" % start
+            elif finish is not None:
+                    cmd = cmd + " and dt_updated <= '%s'" % finish
+            self.cur.execute(cmd)
+            l = []
+            p = None
+            for r in self.cur.fetchall():
+                l.append(self._cleanHistory(r, p, diff))
+                p = r
+            return l
+        except:
+            return []
+
     def objectDelete(self, idx):
         """
         Delete an object from the database.  Assumes inside a


### PR DESCRIPTION
Added the ability to pull out a configuration history between specific times.

This was added as a command line option to pmgrUtils, with the option of producing a short list of changes on the terminal or save the complete set of changed configs into a CSV file.
