### PR TITLE
MNT: remove versioneer.py from MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,3 @@
-include versioneer.py
 include pmgr/_version.py
 include pmgr/pmgrUtils.cfg
 include pmgr/*.ui


### PR DESCRIPTION
Maybe this fixes py3.12 compatibility?  It was still being packaged in the pip install